### PR TITLE
Single-window, typos

### DIFF
--- a/foss4g2023.html
+++ b/foss4g2023.html
@@ -169,7 +169,7 @@
          data-background-opacity="0.6">
     <textarea data-template>
     ## Overview of this talk
-        - Which GRASS?
+        - What is GRASS GIS?
         - Exciting new features in GRASS GIS 8.3
         - Community contributions
         - Get involved
@@ -178,7 +178,7 @@
 
 
 <section>
-    <h2>For newcomers: which GRASS GIS?</h2>
+    <h2>For newcomers: what is GRASS GIS?</h2>
     <div class="columns">
         <div class="column" style="width:59%">
             <ul>
@@ -733,21 +733,26 @@
 
 <section>
     <h2>Single-Window GUI in <b>GRASS 8.2+</b> </h2>
-    <h3>Integration of results from Google Summer of Code 2021</h3>
-    <img src="img/2023/single_layout.png" alt="GRASS GIS and single window GUI" width="85%">
-    <p>
-        One GUI window with optimized layout with dockable widgets.
-    </p>
+    <ul>
+        <li>One GUI window with optimized layout with dockable widgets.</li>
+        <li><font size="+3"><b>Default in 8.3+</b></font></li>
+        <li>Many improvements and fixes to support various platforms</li>
+    </ul>
+    <img src="img/2023/single_layout.png" alt="GRASS GIS and single window GUI" class="stretch">
+
     <p>by Linda Kladivova</p>
-    <p><font size="+3"><b>Default in 8.3+</b></font></p>
 </section>
 
 <section>
     <h2>Dark Theme Support</h2>
-    Interface respects system dark theme.
+    <ul>
+        <li>Interface respects system dark theme.</li>
+        <li>New: fixes for Graphical Modeler</li>
+    </ul>
+
     <br>
     <img src="img/dark_theme_v_clip.png" alt="GRASS GIS and dark theme" class="stretch">
-    <p>by Anna Petrasova, Nicklas Larsson
+    <p>by Anna Petrasova, Nicklas Larsson, Martin Landa
 </section>
 
 <!-- already presented FOSS4G 2022 -->
@@ -1302,7 +1307,7 @@ thredds_crawler</a>.</p>
 <section>
     <h2>GRASS Community Meeting Prague 2023 - Selected outcomes</h2>
     <br>
-    <h3>Graphical Modeler intergrated in Single-Window</h3>
+    <h3>Graphical Modeler integrated in Single-Window</h3>
     <br>
     <div style="position:relative; width:800px; height:480px; margin:0 auto;">
       <img class="fragment fade-out" data-fragment-index="0" src="img/2023/gmodeler_new_window.png" alt="Graphical Modeler as a new window" style="position:absolute;top:0;left:0;" width="100%">


### PR DESCRIPTION
"Which GRASS GIS" sounds rather strange, like there are multiple GRASS GIS. Replaced by "What is GRASS GIS".